### PR TITLE
Fix python version to Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.9-slim
 
 WORKDIR /opt/
 


### PR DESCRIPTION
Using python-3 tries to build cffi and fails (As it is trying to use
Python 3.10)